### PR TITLE
Add internal workflow to auto-create PRs for claude/* branches

### DIFF
--- a/.github/workflows/_auto-pr.yml
+++ b/.github/workflows/_auto-pr.yml
@@ -1,0 +1,12 @@
+# Internal workflow - automatically creates PRs for claude/* branches
+name: Auto PR (Internal)
+
+on:
+  push:
+    branches:
+      - 'claude/**'
+
+jobs:
+  auto-pr:
+    uses: ./.github/workflows/auto-pr.yml
+    secrets: inherit


### PR DESCRIPTION
This internal workflow triggers on push events to claude/* branches and calls the reusable auto-pr.yml workflow to automatically create pull requests.

Follows the repository's naming convention for internal workflows (underscore prefix).

Closes #6

---
Generated with [Claude Code](https://claude.ai/code)