### PR TITLE
feat: auto-add Claude trigger to PR descriptions

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -62,6 +62,8 @@ jobs:
           echo "title=$(git log -1 --format='%s')" >> $GITHUB_OUTPUT
           echo "body<<EOF" >> $GITHUB_OUTPUT
           git log -1 --format='%b' >> $GITHUB_OUTPUT
+          echo "" >> $GITHUB_OUTPUT
+          echo "@claude wait for the workflows to run and then fix any errors if found." >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Determine base branch


### PR DESCRIPTION
When auto-pr creates a PR, it now includes '@claude wait for the workflows to run and then fix any errors if found.' in the PR description. This allows Claude to automatically iterate on CI failures.