### PR TITLE
fix: add WebFetch and WebSearch to default allowed tools

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -8,7 +8,7 @@ on:
         description: 'Allowed tools for Claude Code (comma-separated)'
         required: false
         type: string
-        default: 'Bash(go:*),Bash(make:*),Bash(git:*),Bash(npm:*),Bash(cargo:*),mcp__codesign__sign_file'
+        default: 'Bash(go:*),Bash(make:*),Bash(git:*),Bash(npm:*),Bash(cargo:*),mcp__codesign__sign_file,WebFetch,WebSearch'
       additional-permissions:
         description: 'Additional GitHub API permissions for Claude'
         required: false


### PR DESCRIPTION
Enables Claude to access the internet and fetch URLs by adding WebFetch and WebSearch to the default allowed-tools configuration in the reusable claude.yml workflow.

Fixes #19